### PR TITLE
Removed unnecessary exception handling

### DIFF
--- a/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/evaluators/functions/geo/STGeomFromTextDescriptor.java
+++ b/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/evaluators/functions/geo/STGeomFromTextDescriptor.java
@@ -99,11 +99,8 @@ public class STGeomFromTextDescriptor extends AbstractScalarFunctionDynamicDescr
                             String geometry =
                                     AStringSerializerDeserializer.INSTANCE.deserialize(dataIn).getStringValue();
                             OGCStructure structure;
-                            try {
-                                structure = wktImporter.executeOGC(WktImportFlags.wktImportDefaults, geometry, null);
-                            } catch (IllegalArgumentException e) {
-                                structure = wktImporter.executeOGC(WktImportFlags.wktImportNonTrusted, geometry, null);
-                            }
+
+                            structure = wktImporter.executeOGC(WktImportFlags.wktImportNonTrusted, geometry, null);
                             OGCGeometry ogcGeometry =
                                     OGCGeometry.createFromOGCStructure(structure, SpatialReference.create(4326));
                             ByteBuffer buffer = ogcGeometry.asBinary();
@@ -112,6 +109,7 @@ public class STGeomFromTextDescriptor extends AbstractScalarFunctionDynamicDescr
                             out.writeInt(wKBGeometryBuffer.length);
                             out.write(wKBGeometryBuffer);
                             result.set(resultStorage);
+
                         } catch (IOException e) {
                             throw new InvalidDataFormatException(getIdentifier(), e,
                                     ATypeTag.SERIALIZED_GEOMETRY_TYPE_TAG);

--- a/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/evaluators/functions/geo/STGeomFromTextSRIDDescriptor.java
+++ b/asterixdb/asterix-runtime/src/main/java/org/apache/asterix/runtime/evaluators/functions/geo/STGeomFromTextSRIDDescriptor.java
@@ -109,11 +109,8 @@ public class STGeomFromTextSRIDDescriptor extends AbstractScalarFunctionDynamicD
                                     AStringSerializerDeserializer.INSTANCE.deserialize(dataIn).getStringValue();
                             int srid = (int) AInt64SerializerDeserializer.getLong(data0, offset0 + 1);
                             OGCStructure structure;
-                            try {
-                                structure = wktImporter.executeOGC(WktImportFlags.wktImportDefaults, geometry, null);
-                            } catch (IllegalArgumentException e) {
-                                structure = wktImporter.executeOGC(WktImportFlags.wktImportNonTrusted, geometry, null);
-                            }
+
+                            structure = wktImporter.executeOGC(WktImportFlags.wktImportNonTrusted, geometry, null);
                             OGCGeometry ogcGeometry =
                                     OGCGeometry.createFromOGCStructure(structure, SpatialReference.create(srid));
                             ByteBuffer buffer = ogcGeometry.asBinary();
@@ -122,6 +119,7 @@ public class STGeomFromTextSRIDDescriptor extends AbstractScalarFunctionDynamicD
                             out.writeInt(wKBGeometryBuffer.length);
                             out.write(wKBGeometryBuffer);
                             result.set(resultStorage);
+
                         } catch (IOException e) {
                             throw new InvalidDataFormatException(getIdentifier(), e,
                                     ATypeTag.SERIALIZED_GEOMETRY_TYPE_TAG);


### PR DESCRIPTION
Removed the IllegalArgumentException which was caught unnecessarily and was not rethrown.